### PR TITLE
add ESLint confirmation to accept ES6 used here

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "ecmaFeatures": {
+    "modules": true,
+    "classes": true,
+    "arrowFunctions": true,
+    "blockBindings": true
+  }
+}


### PR DESCRIPTION
This is of course highly optional; but for those of us working with a bunch of different projects at the same time, it's helpful if each one, including demos like this, configure limiting to match the features they are actually using. It is an unfortunate reality of modern JavaScript, it seems that no two projects are using the exact same subset of ES6/2015 and upcoming ES7/2016 features!
